### PR TITLE
Speed up the computation of image segment overlays

### DIFF
--- a/app.py
+++ b/app.py
@@ -712,10 +712,8 @@ def draw_shapes_react(
     print("Time to convert from labels to colored image:", t3 - t2)
     fstc_slices = [
         [
-            array_to_data_url(np.moveaxis(fst_colored, 0, j)[i])
-            if np.any(np.moveaxis(fst_colored, 0, j)[i] != 0)
-            else blank_seg_slices[j]
-            for i in range(fst_colored.shape[j])
+            array_to_data_url(s) if np.any(s != 0) else blank_seg_slices[j]
+            for s in np.moveaxis(fst_colored, 0, j)
         ]
         for j in range(NUM_DIMS_DISPLAYED)
     ]

--- a/app.py
+++ b/app.py
@@ -163,6 +163,9 @@ img_slices, seg_slices = [
 ]
 # initially no slices have been found so we don't draw anything
 found_seg_slices = make_empty_found_segments()
+# store encoded blank slices for each view to save recomputing them for slices
+# containing no colored pixels
+blank_seg_slices = [found_seg_slices[0][0], found_seg_slices[1][0]]
 
 app = dash.Dash(__name__)
 server = app.server
@@ -710,6 +713,8 @@ def draw_shapes_react(
     fstc_slices = [
         [
             array_to_data_url(np.moveaxis(fst_colored, 0, j)[i])
+            if np.any(np.moveaxis(fst_colored, 0, j)[i] != 0)
+            else blank_seg_slices[j]
             for i in range(np.moveaxis(fst_colored, 0, j).shape[0])
         ]
         for j in range(NUM_DIMS_DISPLAYED)
@@ -925,7 +930,6 @@ def populate_3d_graph(
     fig.update_layout(**last_3d_scene)
     end_time = time.time()
     print("serverside 3D generation took: %f seconds" % (end_time - start_time,))
-    # fig.write_json('/tmp/fig.json')
     return (fig, current_render_id)
 
 

--- a/app.py
+++ b/app.py
@@ -715,7 +715,7 @@ def draw_shapes_react(
             array_to_data_url(np.moveaxis(fst_colored, 0, j)[i])
             if np.any(np.moveaxis(fst_colored, 0, j)[i] != 0)
             else blank_seg_slices[j]
-            for i in range(np.moveaxis(fst_colored, 0, j).shape[0])
+            for i in range(fst_colored.shape[j])
         ]
         for j in range(NUM_DIMS_DISPLAYED)
     ]

--- a/app.py
+++ b/app.py
@@ -697,10 +697,13 @@ def draw_shapes_react(
     # convert to a colored image
     fst_colored = image_utils.label_to_colors(
         found_segs_tensor,
-        colormap=["#000000", "#8A2BE2"],
-        alpha=[0, 128],
-        color_class_offset=0,
+        colormap=["#8A2BE2"],
+        alpha=[128],
+        # we map label 0 to the color #000000 using no_map_zero, so we start at
+        # color_class 1
+        color_class_offset=1,
         labels_contiguous=True,
+        no_map_zero=True,
     )
     t3 = time.time()
     print("Time to convert from labels to colored image:", t3 - t2)


### PR DESCRIPTION
It takes a bit of time (1-2 seconds) to compute masks from the drawing, covert these labels into a colored image, and then convert these into png images for transmitting to the client.

Here we propose speeding this up by omitting redundant labels (the zero label) and only computing / sending the parts of images that changed (using bounding boxes).